### PR TITLE
aPointer to Wire

### DIFF
--- a/src/OLED_SSD1306.cpp
+++ b/src/OLED_SSD1306.cpp
@@ -15,7 +15,6 @@
  *
  */
 
-#include <Wire.h>
 #include "OLED_SSD1306.h"
 #include "font.h"
 
@@ -30,17 +29,17 @@ OLED_SSD1306::OLED_SSD1306( uint8_t i2caddr, uint8_t offset ) {
 }
 
 void OLED_SSD1306::SendCommand( unsigned char cmd ) {
-  Wire.beginTransmission( localI2CAddress );
-  Wire.write( 0x80 );
-  Wire.write( cmd );
-  Wire.endTransmission();
+  wire->beginTransmission( localI2CAddress );
+  wire->write( 0x80 );
+  wire->write( cmd );
+  wire->endTransmission();
 }
 
 void OLED_SSD1306::SendChar( unsigned char data ) {
-  Wire.beginTransmission( localI2CAddress );
-  Wire.write( 0x40 );
-  Wire.write( data );
-  Wire.endTransmission();
+  wire->beginTransmission( localI2CAddress );
+  wire->write( 0x40 );
+  wire->write( data );
+  wire->endTransmission();
 }
 
 void OLED_SSD1306::SetCursorXY( unsigned char row, unsigned char col ) {
@@ -141,7 +140,8 @@ void OLED_SSD1306::DisplayOFF(void) {
   SendCommand( 0xAE );  // Set Display Off
 }
 
-void OLED_SSD1306::Init(void) {
+void OLED_SSD1306::Init(TwoWire *twi) {
+	wire = twi ? twi : &Wire;
 
   SendCommand( 0xAE );  // Set Display Off
 

--- a/src/OLED_SSD1306.h
+++ b/src/OLED_SSD1306.h
@@ -17,6 +17,7 @@
 
 #ifndef OLED_SSD1306_H
 #define OLED_SSD1306_H
+#include <Wire.h>
 
 class OLED_SSD1306 {
 
@@ -24,13 +25,14 @@ class OLED_SSD1306 {
 
     uint8_t localI2CAddress;
     uint8_t low_col_offset;
+		TwoWire *wire;
 
   public:
 
     OLED_SSD1306( uint8_t i2caddr );
     OLED_SSD1306( uint8_t i2caddr, uint8_t offset );
 
-    void Init( void );
+    void Init( TwoWire *twi ) = &Wire;
 
     void SendCommand( unsigned char Command );
     void SendChar( unsigned char Data );

--- a/src/mozgy.ino
+++ b/src/mozgy.ino
@@ -1,0 +1,17 @@
+
+#include <Wire.h>
+#include "OLED_SSD1306.h"
+
+OLED_SSD1306 oled(0x3C);
+
+void setup() {
+  Wire.begin();
+  delay(500);
+  oled.Init();
+}
+
+void loop() {
+  oled.SendStrXY("a pointer to wire", 1, 1);
+  delay(10000);
+}
+


### PR DESCRIPTION
Using this library with a DS1621 ( I2C thermometer), and an Arduino Nano, it did not work because the ssd1306 and the ds1621 wanted to share the same pointer to Wire (I learned it reading Adafruit oled library ...)
